### PR TITLE
Integrate Nutlink API into BlockFrost Client

### DIFF
--- a/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/BlockFrostClient.kt
+++ b/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/BlockFrostClient.kt
@@ -13,6 +13,7 @@ import dev.kryptonreborn.blockfrost.mempool.CardanoMempoolApi
 import dev.kryptonreborn.blockfrost.metadata.CardanoMetadataApi
 import dev.kryptonreborn.blockfrost.metrics.MetricsApi
 import dev.kryptonreborn.blockfrost.network.CardanoNetworkApi
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi
 import dev.kryptonreborn.blockfrost.pool.CardanoPoolApi
 import dev.kryptonreborn.blockfrost.scripts.CardanoScriptsApi
 import dev.kryptonreborn.blockfrost.transactions.CardanoTransactionsApi
@@ -41,6 +42,7 @@ class BlockFrostClient {
     private val cardanoPoolApi: CardanoPoolApi
     private val cardanoScriptsApi: CardanoScriptsApi
     private val cardanoTransactionsApi: CardanoTransactionsApi
+    private val nutLinkApi: NutLinkApi
 
     constructor(blockfrostConfig: BlockfrostConfig) : this(Ktor.httpClient(blockfrostConfig))
 
@@ -62,6 +64,7 @@ class BlockFrostClient {
         this.cardanoPoolApi = CardanoPoolApi(httpClient)
         this.cardanoScriptsApi = CardanoScriptsApi(httpClient)
         this.cardanoTransactionsApi = CardanoTransactionsApi(httpClient)
+        this.nutLinkApi = NutLinkApi(httpClient)
     }
 
     /**
@@ -985,6 +988,52 @@ class BlockFrostClient {
      * @return A [Result] containing the result of the transaction submission.
      */
     suspend fun submitTransaction(transaction: String) = handleApiResult { cardanoTransactionsApi.submitTransaction(transaction) }
+
+    /**
+     * List metadata about specific address
+     *
+     * @param address The address to query.
+     * @param queryParameters The query parameters to apply.
+     * @return A [Result] containing a list of metadata about specific address.
+     */
+    suspend fun getNutLink(address: String) = handleApiResult { nutLinkApi.getNutLink(address) }
+
+    /**
+     * List of records of a specific oracle
+     *
+     * @param oracle The oracle to query.
+     * @param queryParameters The query parameters to apply.
+     * @return A [Result] containing a list of records of a specific oracle.
+     */
+    suspend fun getNutLinkTickers(
+        address: String,
+        queryParameters: QueryParameters = QueryParameters(),
+    ) = handleApiResult { nutLinkApi.getNutLinkTickers(address, queryParameters) }
+
+    /**
+     * List of records of a specific ticker
+     *
+     * @param ticker The ticker to query.
+     * @param queryParameters The query parameters to apply.
+     * @return A [Result] containing a list of records of a specific ticker.
+     */
+    suspend fun getNutLinkSpecificTickerForAddress(
+        address: String,
+        ticker: String,
+        queryParameters: QueryParameters = QueryParameters(),
+    ) = handleApiResult { nutLinkApi.getNutLinkSpecificTickerForAddress(address, ticker, queryParameters) }
+
+    /**
+     * List of records of a specific ticker
+     *
+     * @param ticker The ticker to query.
+     * @param queryParameters The query parameters to apply.
+     * @return A [Result] containing a list of records of a specific ticker.
+     */
+    suspend fun getNutLinkSpecificTicker(
+        ticker: String,
+        queryParameters: QueryParameters = QueryParameters(),
+    ) = handleApiResult { nutLinkApi.getNutLinkSpecificTicker(ticker, queryParameters) }
 
     /**
      * Handles the result of an API call, wrapping it in a [Result] object.

--- a/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/NutLinkApi.kt
+++ b/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/NutLinkApi.kt
@@ -1,0 +1,49 @@
+package dev.kryptonreborn.blockfrost.nutlink
+
+import dev.kryptonreborn.blockfrost.base.QueryParameters
+import dev.kryptonreborn.blockfrost.ktor.fetchResource
+import dev.kryptonreborn.blockfrost.nutlink.model.NutLinkAddressMetadata
+import dev.kryptonreborn.blockfrost.nutlink.model.OracleTicker
+import dev.kryptonreborn.blockfrost.nutlink.model.TickerRecord
+import io.ktor.client.HttpClient
+
+internal class NutLinkApi(private val httpClient: HttpClient) {
+    companion object {
+        const val PATH_GET_NUTLINK = "/api/v0/nutlink/:address"
+        const val PATH_GET_NUTLINK_TICKERS = "/api/v0/nutlink/:address/tickers"
+        const val PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS =
+            "/api/v0/nutlink/:address/tickers/:ticker"
+        const val PATH_GET_NUTLINK_SPECIFIC_TICKER = "/api/v0/nutlink/tickers/:ticker"
+    }
+
+    suspend fun getNutLink(address: String) =
+        httpClient.fetchResource<NutLinkAddressMetadata>(
+            PATH_GET_NUTLINK.replace(":address", address),
+        )
+
+    suspend fun getNutLinkTickers(
+        address: String,
+        queryParameters: QueryParameters,
+    ) = httpClient.fetchResource<List<OracleTicker>>(
+        PATH_GET_NUTLINK_TICKERS.replace(":address", address),
+        queryParams = queryParameters.toMap(),
+    )
+
+    suspend fun getNutLinkSpecificTickerForAddress(
+        address: String,
+        ticker: String,
+        queryParameters: QueryParameters,
+    ) = httpClient.fetchResource<List<TickerRecord>>(
+        PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS.replace(":address", address)
+            .replace(":ticker", ticker),
+        queryParams = queryParameters.toMap(),
+    )
+
+    suspend fun getNutLinkSpecificTicker(
+        ticker: String,
+        queryParameters: QueryParameters,
+    ) = httpClient.fetchResource<List<TickerRecord>>(
+        PATH_GET_NUTLINK_SPECIFIC_TICKER.replace(":ticker", ticker),
+        queryParams = queryParameters.toMap(),
+    )
+}

--- a/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/NutLinkAddressMetadata.kt
+++ b/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/NutLinkAddressMetadata.kt
@@ -1,0 +1,25 @@
+package dev.kryptonreborn.blockfrost.nutlink.model
+
+import dev.kryptonreborn.blockfrost.utils.deserializeJsonElement
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * NutLink Address Metadata
+ *
+ * @property address Bech32 encoded address
+ * @property metadataUrl URL of the specific metadata file
+ * @property metadataHash Hash of the metadata file
+ * @property _metadata The cached metadata of the metadata_url file
+ */
+@Serializable
+data class NutLinkAddressMetadata(
+    val address: String,
+    @SerialName("metadata_url") val metadataUrl: String,
+    @SerialName("metadata_hash") val metadataHash: String,
+    @SerialName("metadata") private val _metadata: JsonElement?,
+) {
+    val metadata: Any?
+        get() = _metadata?.deserializeJsonElement()
+}

--- a/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/OracleTicker.kt
+++ b/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/OracleTicker.kt
@@ -1,0 +1,18 @@
+package dev.kryptonreborn.blockfrost.nutlink.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Oracle Ticker
+ *
+ * @property name Name of the ticker
+ * @property count Number of ticker records
+ * @property latestBlock Block height of the latest record
+ */
+@Serializable
+data class OracleTicker(
+    val name: String,
+    val count: Int,
+    @SerialName("latest_block") val latestBlock: Int,
+)

--- a/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/TickerRecord.kt
+++ b/core/src/commonMain/kotlin/dev/kryptonreborn/blockfrost/nutlink/model/TickerRecord.kt
@@ -1,0 +1,25 @@
+package dev.kryptonreborn.blockfrost.nutlink.model
+
+import dev.kryptonreborn.blockfrost.utils.deserializeJsonElement
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Ticker Record
+ *
+ * @property txHash Hash of the transaction
+ * @property blockHeight Block height of the record
+ * @property txIndex Transaction index within the block
+ * @property _payload Content of the ticker
+ */
+@Serializable
+data class TickerRecord(
+    @SerialName("tx_hash") val txHash: String,
+    @SerialName("block_height") val blockHeight: Int,
+    @SerialName("tx_index") val txIndex: Int,
+    @SerialName("payload") private val _payload: JsonElement,
+) {
+    val payload: Any?
+        get() = _payload.deserializeJsonElement()
+}

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/integrationtest/NutLinkApiIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/integrationtest/NutLinkApiIntegrationTest.kt
@@ -1,0 +1,45 @@
+package dev.kryptonreborn.blockfrost.integrationtest
+
+import dev.kryptonreborn.blockfrost.nutlink.model.NutLinkAddressMetadata
+import dev.kryptonreborn.blockfrost.nutlink.model.OracleTicker
+import dev.kryptonreborn.blockfrost.nutlink.model.TickerRecord
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NutLinkApiIntegrationTest : BaseIntegrationTest() {
+    private val address =
+        "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t"
+
+    @Test
+    fun testGetNutLink() =
+        runIntegrationTest {
+            val result = blockfrostClient.getNutLink(address)
+            assertNotNull(result.getOrNull())
+            assertTrue(result.getOrNull() is NutLinkAddressMetadata)
+        }
+
+    @Test
+    fun testGetNutLinkTickers() =
+        runIntegrationTest {
+            val result = blockfrostClient.getNutLinkTickers(address)
+            assertNotNull(result.getOrNull())
+            assertTrue(result.getOrNull() is List<OracleTicker>)
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddress() =
+        runIntegrationTest {
+            val result = blockfrostClient.getNutLinkSpecificTickerForAddress(address, "ADABTC")
+            assertNotNull(result.getOrNull())
+            assertTrue(result.getOrNull() is List<TickerRecord>)
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTicker() =
+        runIntegrationTest {
+            val result = blockfrostClient.getNutLinkSpecificTicker("ADABTC")
+            assertNotNull(result.getOrNull())
+            assertTrue(result.getOrNull() is List<TickerRecord>)
+        }
+}

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/BlockFrostClientTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/BlockFrostClientTest.kt
@@ -96,6 +96,13 @@ import dev.kryptonreborn.blockfrost.network.CardanoNetworkApi.Companion.GET_NETW
 import dev.kryptonreborn.blockfrost.network.CardanoNetworkApi.Companion.QUERY_SUMMARY_BLOCKCHAIN_ERAS
 import dev.kryptonreborn.blockfrost.network.model.EraSummary
 import dev.kryptonreborn.blockfrost.network.model.NetworkInformation
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK_SPECIFIC_TICKER
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK_TICKERS
+import dev.kryptonreborn.blockfrost.nutlink.model.NutLinkAddressMetadata
+import dev.kryptonreborn.blockfrost.nutlink.model.OracleTicker
+import dev.kryptonreborn.blockfrost.nutlink.model.TickerRecord
 import dev.kryptonreborn.blockfrost.pool.CardanoPoolApi.Companion.PATH_LIST_RETIRED_STAKE_POOLS
 import dev.kryptonreborn.blockfrost.pool.CardanoPoolApi.Companion.PATH_LIST_RETIRING_STAKE_POOLS
 import dev.kryptonreborn.blockfrost.pool.CardanoPoolApi.Companion.PATH_LIST_STAKE_POOLS
@@ -2125,6 +2132,103 @@ class BlockFrostClientTest {
         testApiFail(
             CardanoTransactionsApi.PATH_SUBMIT_TRANSACTION,
         ) { blockFrostClient -> blockFrostClient.submitTransaction(anyString) }
+
+    @Test
+    fun testGetAddressMetadata() =
+        runTest {
+            val resource = "src/commonTest/resources/model/nutlink_address_metadata.json"
+            val expectedData = resource.resourceToExpectedData<NutLinkAddressMetadata>()
+            val httpClient =
+                createMockHttpClient(
+                    PATH_GET_NUTLINK.replace(":address", anyString),
+                    Resource(resource).readText(),
+                )
+            val blockFrostClient = BlockFrostClient(httpClient)
+            val result = blockFrostClient.getNutLink(anyString)
+            assertEquals(expectedData, result.getOrNull())
+        }
+
+    @Test
+    fun testGetAddressMetadataFail() =
+        testApiFail(
+            PATH_GET_NUTLINK.replace(":address", anyString),
+        ) { blockFrostClient -> blockFrostClient.getNutLink(anyString) }
+
+    @Test
+    fun testGetNutLinkTickers() =
+        runTest {
+            val resource = "src/commonTest/resources/list_oracle_ticker.json"
+            val expectedData = resource.resourceToExpectedData<List<OracleTicker>>()
+            val httpClient =
+                createMockHttpClient(
+                    PATH_GET_NUTLINK_TICKERS.replace(":address", anyString),
+                    Resource(resource).readText(),
+                )
+            val blockFrostClient = BlockFrostClient(httpClient)
+            val result = blockFrostClient.getNutLinkTickers(anyString)
+            assertEquals(expectedData, result.getOrNull())
+        }
+
+    @Test
+    fun testGetNutLinkTickersFail() =
+        testApiFail(
+            PATH_GET_NUTLINK_TICKERS.replace(":address", anyString),
+        ) { blockFrostClient -> blockFrostClient.getNutLinkTickers(anyString) }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddress() =
+        runTest {
+            val resource = "src/commonTest/resources/list_ticker_record.json"
+            val expectedData = resource.resourceToExpectedData<List<TickerRecord>>()
+            val httpClient =
+                createMockHttpClient(
+                    PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS.replace(":address", anyString)
+                        .replace(":ticker", anyString),
+                    Resource(resource).readText(),
+                )
+            val blockFrostClient = BlockFrostClient(httpClient)
+            val result = blockFrostClient.getNutLinkSpecificTickerForAddress(anyString, anyString)
+            assertEquals(expectedData, result.getOrNull())
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddressFail() =
+        testApiFail(
+            PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS.replace(":address", anyString)
+                .replace(":ticker", anyString),
+        ) { blockFrostClient ->
+            blockFrostClient.getNutLinkSpecificTickerForAddress(
+                anyString,
+                anyString,
+            )
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTicker() =
+        runTest {
+            val resource = "src/commonTest/resources/list_ticker_record.json"
+            val expectedData = resource.resourceToExpectedData<List<TickerRecord>>()
+            val httpClient =
+                createMockHttpClient(
+                    PATH_GET_NUTLINK_SPECIFIC_TICKER.replace(":address", anyString)
+                        .replace(":ticker", anyString),
+                    Resource(resource).readText(),
+                )
+            val blockFrostClient = BlockFrostClient(httpClient)
+            val result = blockFrostClient.getNutLinkSpecificTicker(anyString)
+            assertEquals(expectedData, result.getOrNull())
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerFail() =
+        testApiFail(
+            PATH_GET_NUTLINK_SPECIFIC_TICKER.replace(":address", anyString)
+                .replace(":ticker", anyString),
+        ) { blockFrostClient ->
+            blockFrostClient.getNutLinkSpecificTicker(
+                anyString,
+            )
+        }
 
     private fun testApiFail(
         path: String,

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/NutLinkApiTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/NutLinkApiTest.kt
@@ -1,0 +1,163 @@
+package dev.kryptonreborn.blockfrost.unittest.nutlink
+
+import com.goncalossilva.resources.Resource
+import dev.kryptonreborn.blockfrost.TestKtorClient
+import dev.kryptonreborn.blockfrost.TestKtorClient.resourceToExpectedData
+import dev.kryptonreborn.blockfrost.base.BadRequestException
+import dev.kryptonreborn.blockfrost.base.BlockfrostException
+import dev.kryptonreborn.blockfrost.base.QueryParameters
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK
+import dev.kryptonreborn.blockfrost.nutlink.NutLinkApi.Companion.PATH_GET_NUTLINK_TICKERS
+import dev.kryptonreborn.blockfrost.nutlink.model.NutLinkAddressMetadata
+import dev.kryptonreborn.blockfrost.nutlink.model.OracleTicker
+import dev.kryptonreborn.blockfrost.nutlink.model.TickerRecord
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class NutLinkApiTest {
+    @Test
+    fun testGetAddressMetadataReturn200() =
+        runTest {
+            val resource = "src/commonTest/resources/model/nutlink_address_metadata.json"
+            val content = resource.resourceToExpectedData<NutLinkAddressMetadata>()
+            val api = createNutlinkApi(resource, PATH_GET_NUTLINK)
+            val result = api.getNutLink("address")
+            assertEquals(content, result)
+        }
+
+    @Test
+    fun testGetAddressMetadataReturn200WithFailData() =
+        runTest {
+            testApiWithBadRequest(
+                PATH_GET_NUTLINK,
+                HttpStatusCode.OK,
+            ) { it.getNutLink("address") }
+        }
+
+    @Test
+    fun testGetAddressMetadataReturn400() =
+        runTest {
+            testApiWithBadRequest(
+                PATH_GET_NUTLINK,
+                HttpStatusCode.BadRequest,
+            ) { it.getNutLink("address") }
+        }
+
+    @Test
+    fun testGetNutLinkTickersReturn200() =
+        runTest {
+            val resource = "src/commonTest/resources/list_oracle_ticker.json"
+            val content = resource.resourceToExpectedData<List<OracleTicker>>()
+            val api = createNutlinkApi(resource, PATH_GET_NUTLINK_TICKERS)
+            val result = api.getNutLinkTickers("address", QueryParameters())
+            assertEquals(content, result)
+        }
+
+    @Test
+    fun testGetNutLinkTickersReturn200WithFailData() =
+        runTest {
+            testApiWithBadRequest(
+                PATH_GET_NUTLINK_TICKERS,
+                HttpStatusCode.OK,
+            ) { it.getNutLinkTickers("address", QueryParameters()) }
+        }
+
+    @Test
+    fun testGetNutLinkTickersReturn400() =
+        runTest {
+            testApiWithBadRequest(
+                PATH_GET_NUTLINK_TICKERS,
+                HttpStatusCode.BadRequest,
+            ) { it.getNutLinkTickers("address", QueryParameters()) }
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddressReturn200() =
+        runTest {
+            val resource = "src/commonTest/resources/list_ticker_record.json"
+            val content = resource.resourceToExpectedData<List<TickerRecord>>()
+            val api = createNutlinkApi(resource, NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS)
+            val result = api.getNutLinkSpecificTickerForAddress("address", "ticker", QueryParameters())
+            assertEquals(content, result)
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddressReturn200WithFailData() =
+        runTest {
+            testApiWithBadRequest(
+                NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS,
+                HttpStatusCode.OK,
+            ) { it.getNutLinkSpecificTickerForAddress("address", "ticker", QueryParameters()) }
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerForAddressReturn400() =
+        runTest {
+            testApiWithBadRequest(
+                NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER_FOR_ADDRESS,
+                HttpStatusCode.BadRequest,
+            ) { it.getNutLinkSpecificTickerForAddress("address", "ticker", QueryParameters()) }
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerReturn200() =
+        runTest {
+            val resource = "src/commonTest/resources/list_ticker_record.json"
+            val content = resource.resourceToExpectedData<List<TickerRecord>>()
+            val api = createNutlinkApi(resource, NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER)
+            val result = api.getNutLinkSpecificTicker("ticker", QueryParameters())
+            assertEquals(content, result)
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerReturn200WithFailData() =
+        runTest {
+            testApiWithBadRequest(
+                NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER,
+                HttpStatusCode.OK,
+            ) { it.getNutLinkSpecificTicker("ticker", QueryParameters()) }
+        }
+
+    @Test
+    fun testGetNutLinkSpecificTickerReturn400() =
+        runTest {
+            testApiWithBadRequest(
+                NutLinkApi.PATH_GET_NUTLINK_SPECIFIC_TICKER,
+                HttpStatusCode.BadRequest,
+            ) { it.getNutLinkSpecificTicker("ticker", QueryParameters()) }
+        }
+
+    private fun createNutlinkApi(
+        resource: String,
+        path: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ) = NutLinkApi(
+        TestKtorClient.createMockHttpClient(
+            path.replace(":address", "address")
+                .replace(":ticker", "ticker"),
+            Resource(resource).readText(),
+            status,
+        ),
+    )
+
+    private suspend fun testApiWithBadRequest(
+        path: String,
+        statusCode: HttpStatusCode,
+        apiCall: suspend (NutLinkApi) -> Unit,
+    ) {
+        val api =
+            createNutlinkApi(
+                "src/commonTest/resources/test_data_errors_response.json",
+                path,
+                statusCode,
+            )
+        val exception = assertFailsWith<BlockfrostException> { apiCall(api) }
+        assertTrue(exception is BadRequestException)
+        assertEquals("Backend did not understand your request.", exception.message)
+    }
+}

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/NutLinkAddressMetadataTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/NutLinkAddressMetadataTest.kt
@@ -1,0 +1,39 @@
+package dev.kryptonreborn.blockfrost.unittest.nutlink.model
+
+import dev.kryptonreborn.blockfrost.TestKtorClient.resourceToExpectedData
+import dev.kryptonreborn.blockfrost.nutlink.model.NutLinkAddressMetadata
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NutLinkAddressMetadataTest {
+    @Test
+    fun testDeserialization() {
+        val content =
+            "src/commonTest/resources/model/nutlink_address_metadata.json".resourceToExpectedData<NutLinkAddressMetadata>()
+
+        assertEquals(
+            "addr1qxqs59lphg8g6qndelq8xwqn60ag3aeyfcp33c2kdp46a09re5df3pzwwmyq946axfcejy5n4x0y99wqpgtp2gd0k09qsgy6pz",
+            content.address,
+        )
+        assertEquals("https://nut.link/metadata.json", content.metadataUrl)
+        assertEquals(
+            "6bf124f217d0e5a0a8adb1dbd8540e1334280d49ab861127868339f43b3948af",
+            content.metadataHash,
+        )
+        assertEquals(emptyMap<String, Any>(), content.metadata)
+    }
+
+    @Test
+    fun testGetMetadata() {
+        val content =
+            NutLinkAddressMetadata(
+                "addr1qxqs59lphg8g6qndelq8xwqn60ag3aeyfcp33c2kdp46a09re5df3pzwwmyq946axfcejy5n4x0y99wqpgtp2gd0k09qsgy6pz",
+                "https://nut.link/metadata.json",
+                "6bf124f217d0e5a0a8adb1dbd8540e1334280d49ab861127868339f43b3948af",
+                JsonObject(mapOf("key" to JsonPrimitive("value"))),
+            )
+        assertEquals(mapOf("key" to "value"), content.metadata)
+    }
+}

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/OracleTickerTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/OracleTickerTest.kt
@@ -1,0 +1,18 @@
+package dev.kryptonreborn.blockfrost.unittest.nutlink.model
+
+import dev.kryptonreborn.blockfrost.TestKtorClient.parseFirstElementInArray
+import dev.kryptonreborn.blockfrost.nutlink.model.OracleTicker
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OracleTickerTest {
+    @Test
+    fun testDeserialization() {
+        val content =
+            "src/commonTest/resources/list_oracle_ticker.json".parseFirstElementInArray<OracleTicker>()
+
+        assertEquals("ADAUSD", content.name)
+        assertEquals(1980038, content.count)
+        assertEquals(2657092, content.latestBlock)
+    }
+}

--- a/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/TickerRecordTest.kt
+++ b/core/src/commonTest/kotlin/dev/kryptonreborn/blockfrost/unittest/nutlink/model/TickerRecordTest.kt
@@ -1,0 +1,37 @@
+package dev.kryptonreborn.blockfrost.unittest.nutlink.model
+
+import dev.kryptonreborn.blockfrost.TestKtorClient.parseFirstElementInArray
+import dev.kryptonreborn.blockfrost.nutlink.model.TickerRecord
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TickerRecordTest {
+    @Test
+    fun testDeserialization() {
+        val content =
+            "src/commonTest/resources/list_ticker_record.json".parseFirstElementInArray<TickerRecord>()
+
+        assertEquals(
+            "e8073fd5318ff43eca18a852527166aa8008bee9ee9e891f585612b7e4ba700b",
+            content.txHash,
+        )
+        assertEquals(2657092, content.blockHeight)
+        assertEquals(8, content.txIndex)
+        assertTrue(content.payload is List<*>)
+    }
+
+    @Test
+    fun getGetPayload() {
+        val content =
+            TickerRecord(
+                "e8073fd5318ff43eca18a852527166aa8008bee9ee9e891f585612b7e4ba700b",
+                2657092,
+                8,
+                JsonObject(mapOf("key" to JsonPrimitive("value"))),
+            )
+        assertEquals(mapOf("key" to "value"), content.payload)
+    }
+}

--- a/core/src/commonTest/resources/list_oracle_ticker.json
+++ b/core/src/commonTest/resources/list_oracle_ticker.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "ADAUSD",
+    "count": 1980038,
+    "latest_block": 2657092
+  },
+  {
+    "name": "ADAEUR",
+    "count": 1980038,
+    "latest_block": 2657092
+  },
+  {
+    "name": "ADABTC",
+    "count": 1980038,
+    "latest_block": 2657092
+  }
+]

--- a/core/src/commonTest/resources/list_ticker_record.json
+++ b/core/src/commonTest/resources/list_ticker_record.json
@@ -1,0 +1,17 @@
+[
+  {
+    "tx_hash": "e8073fd5318ff43eca18a852527166aa8008bee9ee9e891f585612b7e4ba700b",
+    "block_height": 2657092,
+    "tx_index": 8,
+    "payload": [
+      {
+        "source": "coinGecko",
+        "value": "1.29"
+      },
+      {
+        "source": "cryptoCompare",
+        "value": "1.283"
+      }
+    ]
+  }
+]

--- a/core/src/commonTest/resources/model/nutlink_address_metadata.json
+++ b/core/src/commonTest/resources/model/nutlink_address_metadata.json
@@ -1,0 +1,6 @@
+{
+  "address": "addr1qxqs59lphg8g6qndelq8xwqn60ag3aeyfcp33c2kdp46a09re5df3pzwwmyq946axfcejy5n4x0y99wqpgtp2gd0k09qsgy6pz",
+  "metadata_url": "https://nut.link/metadata.json",
+  "metadata_hash": "6bf124f217d0e5a0a8adb1dbd8540e1334280d49ab861127868339f43b3948af",
+  "metadata": {}
+}

--- a/example/composeApp/src/commonMain/kotlin/presentation/ui/home/viewmodel/HomeState.kt
+++ b/example/composeApp/src/commonMain/kotlin/presentation/ui/home/viewmodel/HomeState.kt
@@ -196,6 +196,17 @@ data class HomeState(
                             "GetTransactionRedeemers",
                         ),
                 ),
+            "NutLink Api" to
+                HomeCardanoApi(
+                    show = false,
+                    items =
+                        listOf(
+                            "GetNutLink",
+                            "GetNutLinkTickers",
+                            "GetNutLinkSpecificTickerForAddress",
+                            "GetNutLinkSpecificTicker",
+                        ),
+                ),
         ),
 )
 

--- a/example/composeApp/src/commonMain/kotlin/presentation/ui/result/viewmodel/ResultEvent.kt
+++ b/example/composeApp/src/commonMain/kotlin/presentation/ui/result/viewmodel/ResultEvent.kt
@@ -170,4 +170,12 @@ sealed class ResultEvent(val id: String) {
     data object GetTransactionMetadataCbor : ResultEvent("GetTransactionMetadataCbor")
 
     data object GetTransactionRedeemers : ResultEvent("GetTransactionRedeemers")
+
+    data object GetNutLink : ResultEvent("GetNutLink")
+
+    data object GetNutLinkTickers : ResultEvent("GetNutLinkTickers")
+
+    data object GetNutLinkSpecificTickerForAddress : ResultEvent("GetNutLinkSpecificTickerForAddress")
+
+    data object GetNutLinkSpecificTicker : ResultEvent("GetNutLinkSpecificTicker")
 }

--- a/example/composeApp/src/commonMain/kotlin/presentation/ui/result/viewmodel/ResultViewModel.kt
+++ b/example/composeApp/src/commonMain/kotlin/presentation/ui/result/viewmodel/ResultViewModel.kt
@@ -35,6 +35,9 @@ class ResultViewModel : ViewModel() {
     private val scriptHash = "65c197d565e88a20885e535f93755682444d3c02fd44dd70883fe89e"
     private val datumHash = "db583ad85881a96c73fbb26ab9e24d1120bb38f45385664bb9c797a2ea8d9a2d"
     private val hashTransaction = "37746d2fa855de3095792d2e534deea9f1dbb43a113eec5d1dfad3963d8bb09d"
+    private val nutlinkAdrees =
+        "addr1q85yx2w7ragn5sx6umgmtjpc3865s9sg59sz4rrh6f90kgwfwlzu3w8ttacqg89mkdgwshwnplj5c5n9f8dhp0h55q2q7qm63t"
+
     private val blockFrostClient =
         BlockFrostClient(
             BlockfrostConfig(
@@ -542,6 +545,26 @@ class ResultViewModel : ViewModel() {
                         blockFrostClient.getTransactionWithdrawals(hashTransaction)
                     }
                 }
+
+                ResultEvent.GetNutLink ->
+                    getResponse {
+                        blockFrostClient.getNutLink(nutlinkAdrees)
+                    }
+
+                ResultEvent.GetNutLinkSpecificTicker ->
+                    getResponse {
+                        blockFrostClient.getNutLinkSpecificTicker("ADABTC")
+                    }
+
+                ResultEvent.GetNutLinkSpecificTickerForAddress ->
+                    getResponse {
+                        blockFrostClient.getNutLinkSpecificTickerForAddress(nutlinkAdrees, "ADABTC")
+                    }
+
+                ResultEvent.GetNutLinkTickers ->
+                    getResponse {
+                        blockFrostClient.getNutLinkTickers(address)
+                    }
             }
         }
     }
@@ -651,6 +674,10 @@ class ResultViewModel : ViewModel() {
                 "GetTransactionMetadata" to ResultEvent.GetTransactionMetadata,
                 "GetTransactionMetadataCbor" to ResultEvent.GetTransactionMetadataCbor,
                 "GetTransactionRedeemers" to ResultEvent.GetTransactionRedeemers,
+                "GetNutLink" to ResultEvent.GetNutLink,
+                "GetNutLinkTickers" to ResultEvent.GetNutLinkTickers,
+                "GetNutLinkSpecificTickerForAddress" to ResultEvent.GetNutLinkSpecificTickerForAddress,
+                "GetNutLinkSpecificTicker" to ResultEvent.GetNutLinkSpecificTicker,
             )
     }
 }


### PR DESCRIPTION
# Pull Request (PR) Summary

- This PR introduces the Nutlink API to the BlockFrost client, enhancing the client's capabilities by providing access to metadata associated with Cardano addresses through new API endpoints.

## Changes Description

The addition of the Nutlink API represents a significant enhancement to the BlockFrost client, enabling developers to access and interact with metadata linked to Cardano addresses. This metadata is crucial for applications that rely on oracle services for decentralized data verification on the Cardano blockchain.

### New Endpoints
- **`getNutLink`**: Retrieves metadata about a specific address, offering insights into its interactions and roles within oracle services.
- **`getNutLinkTickers`**: Lists records from a specific oracle, providing a comprehensive view of the oracle's published data.
- **`getNutLinkSpecificTickerForAddress`**: Lists records of a specific ticker associated with a given address, allowing users to track specific data feeds.
- **`getNutLinkSpecificTicker`**: Lists records of a specific ticker, enabling detailed analysis of data provided by oracles.

### Testing
- **Unit Tests**: Comprehensive unit tests have been added to verify the functionality of each new endpoint, ensuring they perform as expected under various scenarios.
- **Integration Tests**: Integration tests have been implemented to test the new endpoints in a live environment, confirming their reliability and correct integration with the existing BlockFrost infrastructure.

These new endpoints are designed to provide developers with powerful tools for building applications that require reliable and verifiable data from decentralized sources.

## Related Issue(s)

- Fixes # (issue number)  // Please replace with actual issue number if applicable

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] My PR is targeting the `main` branch
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or my feature works
- [x] All new and existing tests passed.